### PR TITLE
Use kicad_pcb as BOM in kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,4 +1,4 @@
-bom: ''
+bom: hw/sch_pcb/USBI2C01.kicad_pcb
 eda:
   pcb: hw/sch_pcb/USBI2C01.kicad_pcb
   type: kicad


### PR DESCRIPTION
Hey,  you need some kind of BOM to put the project on Kitspace. The quick-fix is to just infer the BOM from the .kicad_pcb but as you can see from [the preview](http://try-mlab.preview.kitspace.org/boards/github.com/kitspace-forks/USBI2C01/) it doesn't allow people to buy the parts. If you would like to work on a separate BOM maybe our [BOM Builder](https://kitspace.org/bom-builder/) could help you, happy to give you beta access, just let me know. 